### PR TITLE
fix(theme): remove duplicate font-size definition

### DIFF
--- a/components/css-baseline/__tests__/__snapshots__/baseline.test.tsx.snap
+++ b/components/css-baseline/__tests__/__snapshots__/baseline.test.tsx.snap
@@ -49,7 +49,6 @@ initialize {
         p,
         small {
           font-weight: 400;
-          font-size: 0.8571rem;
           color: inherit;
           letter-spacing: 0.1429rem;
           font-family: &quot;Circular Std Book&quot;, &quot;PingFang SC&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Roboto&quot;, &quot;Oxygen&quot;, &quot;Ubuntu&quot;, &quot;Cantarell&quot;, &quot;Fira Sans&quot;, &quot;Droid Sans&quot;, &quot;Helvetica Neue&quot;, sans-serif;
@@ -64,7 +63,7 @@ initialize {
         small {
           margin: 0;
           line-height: 1.5;
-          font-size: 0.875rem;
+          font-size: 0.8571rem;
         }
 
         b {
@@ -391,7 +390,6 @@ initialize {
         p,
         small {
           font-weight: 400;
-          font-size: 0.8571rem;
           color: inherit;
           letter-spacing: 0.1429rem;
           font-family: &quot;Circular Std Book&quot;, &quot;PingFang SC&quot;, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Roboto&quot;, &quot;Oxygen&quot;, &quot;Ubuntu&quot;, &quot;Cantarell&quot;, &quot;Fira Sans&quot;, &quot;Droid Sans&quot;, &quot;Helvetica Neue&quot;, sans-serif;
@@ -406,7 +404,7 @@ initialize {
         small {
           margin: 0;
           line-height: 1.5;
-          font-size: 0.875rem;
+          font-size: 0.8571rem;
         }
 
         b {

--- a/components/css-baseline/css-baseline.tsx
+++ b/components/css-baseline/css-baseline.tsx
@@ -52,7 +52,6 @@ const CssBaseline: React.FC<React.PropsWithChildren<{}>> = ({ children }) => {
         p,
         small {
           font-weight: 400;
-          font-size: 0.8571rem;
           color: inherit;
           letter-spacing: 0.1429rem;
           font-family: ${theme.font.sans};
@@ -67,7 +66,7 @@ const CssBaseline: React.FC<React.PropsWithChildren<{}>> = ({ children }) => {
         small {
           margin: 0;
           line-height: 1.5;
-          font-size: 0.875rem;
+          font-size: 0.8571rem;
         }
 
         b {


### PR DESCRIPTION
there're duplicate `font-size` definitions for `small`

## Checklist

- [x] Fix linting errors
- [x] Tests have been added / updated (or snapshots)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/react-ui/19)
<!-- Reviewable:end -->
